### PR TITLE
fix: make var names unique when read 10x h5.

### DIFF
--- a/conga/preprocess.py
+++ b/conga/preprocess.py
@@ -227,6 +227,7 @@ def read_adata(
 
     elif gex_data_type == '10x_h5':
         adata = sc.read_10x_h5( gex_data, gex_only=gex_only )
+        adata.var_names_make_unique()
 
     elif gex_data_type == 'loom':
         adata = sc.read_loom( gex_data )


### PR DESCRIPTION
Hi there, 

I make the variable names unique after read 10X H5 file to solve the errors and warnings when run `merge_samples.py`. 

In brief, the error `ValueError: cannot reindex from a duplicate axis` raises from ` new_adata = all_data[0][2].concatenate(*[x[2] for x in all_data[1:]])`; the warning `Variable names are not unique` from `read_adata()`. 

Below is the detailed message:

```
Variable names are not unique. To make them unique, call `.var_names_make_unique`.
reading: /WORKDIR/outs/filtered_feature_bc_matrix.h5 of type 10x_h5
(5659, 32285) /WORKDIR/outs/filtered_feature_bc_matrix.h5
/CONGA_DIR/conga/preprocess.py:210: DeprecationWarning: Use is_view instead of isview, isview will be removed in the future.
  if adata.isview: # this is so weird
Variable names are not unique. To make them unique, call `.var_names_make_unique`.
reading: /WORKDIR/outs/filtered_feature_bc_matrix.h5 of type 10x_h5
(4861, 32285) /WORKDIR/outs/filtered_feature_bc_matrix.h5
/CONGA_DIR/conga/preprocess.py:210: DeprecationWarning: Use is_view instead of isview, isview will be removed in the future.
  if adata.isview: # this is so weird
Traceback (most recent call last):
  File "/CONGA_DIR/scripts/merge_samples.py", line 79, in <module>
    new_adata = all_data[0][2].concatenate(*[x[2] for x in all_data[1:]])
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/anndata/_core/anndata.py", line 1705, in concatenate
    pairwise=False,
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/anndata/_core/merge.py", line 815, in concat
    [getattr(a, alt_dim) for a in adatas], alt_indices, merge
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/anndata/_core/merge.py", line 526, in merge_dataframes
    dfs = [df.reindex(index=new_index) for df in dfs]
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/anndata/_core/merge.py", line 526, in <listcomp>
    dfs = [df.reindex(index=new_index) for df in dfs]
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/util/_decorators.py", line 309, in wrapper
    return func(*args, **kwargs)
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/core/frame.py", line 4036, in reindex
    return super().reindex(**kwargs)
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/core/generic.py", line 4464, in reindex
    axes, level, limit, tolerance, method, fill_value, copy
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/core/frame.py", line 3883, in _reindex_axes
    index, method, copy, level, fill_value, limit, tolerance
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/core/frame.py", line 3905, in _reindex_index
    allow_dups=False,
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/core/generic.py", line 4532, in _reindex_with_indexers
    copy=copy,
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/core/internals/managers.py", line 1285, in reindex_indexer
    self.axes[axis]._can_reindex(indexer)
  File "/home/USER/.conda/envs/conga/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 3292, in _can_reindex
    raise ValueError("cannot reindex from a duplicate axis")
ValueError: cannot reindex from a duplicate axis
```