### PR TITLE
Hotfix/save distfile

### DIFF
--- a/conga/preprocess.py
+++ b/conga/preprocess.py
@@ -227,6 +227,7 @@ def read_adata(
 
     elif gex_data_type == '10x_h5':
         adata = sc.read_10x_h5( gex_data, gex_only=gex_only )
+        adata.var_names_make_unique()
 
     elif gex_data_type == 'loom':
         adata = sc.read_loom( gex_data )

--- a/conga/preprocess.py
+++ b/conga/preprocess.py
@@ -1454,7 +1454,7 @@ def make_tcrdist_kernel_pcs_file_from_clones_file(
         D = np.loadtxt(input_distfile)
 
     if output_distfile is not None:
-        np.savetxt( distfile, D.astype(float), fmt='%.1f')
+        np.savetxt( output_distfile, D.astype(float), fmt='%.1f')
 
     n_components = min( n_components_in, D.shape[0] )
 


### PR DESCRIPTION
Hi there,

I fix the variable name of output distfile in function `make_tcrdist_kernel_pcs_file_from_clones_file()` to solve the error below: 

```
Using C++ TCRdist calculator
util.run_command: cmd= /CONGA_DIR/tcrdist_cpp/bin/find_neighbors -f clones_AB.dist_50_kpcs_tcrs.tsv --only_tcrdists -d /CONGA_DIR/tcrdist_cpp/db/tcrdist_info_mouse.txt -o clones_AB.dist_50_kpcs
Traceback (most recent call last):
  File "/CONGA_DIR/scripts/merge_samples.py", line 123, in <module>
    output_distfile=args.output_distfile )
  File "/CONGA_DIR/conga/preprocess.py", line 1343, in make_tcrdist_kernel_pcs_file_from_clones_file
    np.savetxt( distfile, D.astype(float), fmt='%.1f')
NameError: name 'distfile' is not defined
```

PS: thank you for developing CONGA!

-Mark