### PR TITLE
Support environment variable for preferred SVG to PNG utility

### DIFF
--- a/conga/convert_svg_to_png.py
+++ b/conga/convert_svg_to_png.py
@@ -168,11 +168,11 @@ def convert_svg_to_png(
             exit()
 
     tools_to_test = CONVERT_MAP.keys()
-    if os.getenv('CONGA_PNG_TO_SVG_UTILITY') != None
+    if os.getenv('CONGA_PNG_TO_SVG_UTILITY') != None:
         tools_to_test = [os.getenv('CONGA_PNG_TO_SVG_UTILITY')]
     
     for tool_name in tools_to_test:
-        if not fn in CONVERT_MAP.keys():
+        if not tool_name in CONVERT_MAP.keys():
             errmsg = 'Error: unknown conversion tool: {}\n'.format(tool_name)
             print(errmsg)
             stderr.write( errmsg )

--- a/conga/convert_svg_to_png.py
+++ b/conga/convert_svg_to_png.py
@@ -49,7 +49,7 @@ def convert_with_inkscape(svgfile, pngfile):
 
         if isfile( pngfile ):
             ## success
-            return
+            return True
         else:
             print(f'conga.convert_svg_to_png: inkscape failed, command="{cmd}"')
 
@@ -77,7 +77,7 @@ def convert_with_inkscape(svgfile, pngfile):
 
         if isfile( pngfile ):
             ## success
-            return
+            return True
 
         # this is the old syntax
         cmd = '{} --export-png {} {}'.format( PATH_TO_INKSCAPE, pngfile_full, svgfile_full )
@@ -119,7 +119,7 @@ def convert_with_cairosvg(svgfile, pngfile):
 
         if isfile( pngfile ):
             ## success
-            return
+            return True
         else:
             print(f'conga.convert_svg_to_png: 3rd try failed, command="{cmd}"')
 
@@ -137,7 +137,7 @@ def convert_with_magick(svgfile, pngfile):
 
         if isfile( pngfile ):
             ## success
-            return
+            return True
         else:
             print(f'conga.convert_svg_to_png: 4th try failed, command="{cmd}"')
 
@@ -163,7 +163,7 @@ def convert_svg_to_png(
         print(errmsg)
         stderr.write( errmsg )
         if allow_missing:
-            return
+            return True
         else:
             exit()
 

--- a/conga/convert_svg_to_png.py
+++ b/conga/convert_svg_to_png.py
@@ -2,6 +2,7 @@ import os
 from os import system
 from os.path import isfile
 from sys import stderr, exit
+from shutil import which
 from collections import OrderedDict
 
 # modify this (ie PATH_TO_INKSCAPE) if you have command line inkscape installed
@@ -157,8 +158,6 @@ def convert_svg_to_png(
         allow_missing=False,
         allow_failure=True
 ):
-    from shutil import which
-
     if not isfile(svgfile):
         errmsg = 'Error: convert_svg_to_png: svgfile does not exist: {}\n'.format(svgfile)
         print(errmsg)

--- a/conga/convert_svg_to_png.py
+++ b/conga/convert_svg_to_png.py
@@ -2,6 +2,7 @@ import os
 from os import system
 from os.path import isfile
 from sys import stderr, exit
+from collections import OrderedDict
 
 # modify this (ie PATH_TO_INKSCAPE) if you have command line inkscape installed
 #   in a different place
@@ -141,13 +142,13 @@ def convert_with_magick(svgfile, pngfile):
 
     return False
 
-CONVERT_MAP = {
-    'convert': convert_with_convert,
-    'inkscape': convert_with_inkscape,
-    'rsvg': convert_with_rsvg,
-    'cairosvg': convert_with_cairosvg,
-    'magick': convert_with_magick,
-}
+CONVERT_MAP = OrderedDict([
+    ('convert', convert_with_convert),
+    ('inkscape', convert_with_inkscape),
+    ('rsvg', convert_with_rsvg),
+    ('cairosvg', convert_with_cairosvg),
+    ('magick', convert_with_magick),
+])
 
 def convert_svg_to_png(
         svgfile,

--- a/conga/convert_svg_to_png.py
+++ b/conga/convert_svg_to_png.py
@@ -24,7 +24,7 @@ if isfile(ALT_PATH_TO_INKSCAPE) and not isfile(PATH_TO_INKSCAPE):
 ## like cairosvg
 ##
 
-def convert_with_convert(svgfile, pngfile):
+def convert_with_convert(svgfile, pngfile, verbose=False):
     if which('convert') is not None:
         cmd = 'convert {} {}'.format( svgfile, pngfile )
         if verbose:
@@ -39,7 +39,7 @@ def convert_with_convert(svgfile, pngfile):
         
     return False
 
-def convert_with_inkscape(svgfile, pngfile):
+def convert_with_inkscape(svgfile, pngfile, verbose=False):
     if which('inkscape') is not None:
         ## cmdline inkscape: new options
         cmd = 'inkscape -o {} {}'.format( pngfile, svgfile )
@@ -92,7 +92,7 @@ def convert_with_inkscape(svgfile, pngfile):
 
     return False
 
-def convert_with_rsvg(svgfile, pngfile):
+def convert_with_rsvg(svgfile, pngfile, verbose=False):
     if which('rsvg-convert') is not None:
         ## another possibility
         cmd = 'rsvg-convert {} -o {}'.format( svgfile, pngfile )
@@ -109,7 +109,7 @@ def convert_with_rsvg(svgfile, pngfile):
     return False
 
 
-def convert_with_cairosvg(svgfile, pngfile):
+def convert_with_cairosvg(svgfile, pngfile, verbose=False):
     if which('cairosvg') is not None:
         ## another possibility
         cmd = f'cairosvg -f png -o {pngfile} {svgfile}'
@@ -127,7 +127,7 @@ def convert_with_cairosvg(svgfile, pngfile):
 
 
 
-def convert_with_magick(svgfile, pngfile):
+def convert_with_magick(svgfile, pngfile, verbose=False):
     if which('magick') is not None:
         ## another possibility
         cmd = 'magick convert {} {}'.format( svgfile, pngfile )
@@ -178,7 +178,7 @@ def convert_svg_to_png(
             stderr.write( errmsg )
             continue
         
-        success = CONVERT_MAP[tool_name](svgfile, pngfile)
+        success = CONVERT_MAP[tool_name](svgfile, pngfile, verbose)
         if success:
             return
 


### PR DESCRIPTION
Hello - 

We are running CoNGA in a docker container in a headless way on our cluster. We noticed that in some environments the PNG seq logos are kind of malformed. We think that choosing the right utility will effect this. As it stands, CoNGA basically iterates tools in a pre-defined order of priority. If 'convert' is present, it'll be used. This PR refactors the process for selecting the tools. By default it should not change behavior at all. However, it allows the user to specific the environment variable CONGA_PNG_TO_SVG_UTILITY, which could be any of: convert, inkscape, rsvg, cairosvg, or magick. If defined, it will preferentially use that tool. 