### PR TITLE
Update fixup_gene_name() to select the lowest expect allele, rather than just *01 when no allele provided.

### DIFF
--- a/conga/tcrdist/make_10x_clones_file.py
+++ b/conga/tcrdist/make_10x_clones_file.py
@@ -5,7 +5,6 @@ from .all_genes import all_genes
 #import parse_tsv
 from collections import Counter
 from itertools import chain
-from natsort import natsorted
 import sys
 import pandas as pd
 from ..util import organism2vdj_type, IG_VDJ_TYPE
@@ -27,7 +26,7 @@ def fixup_gene_name( gene, gene_suffix, expected_gene_names ):
     # This should select the lowest allele
     if '*' not in gene:
         toTest = gene + '*'
-        for geneName in natsorted(expected_gene_names.keys()):
+        for geneName in sorted(expected_gene_names.keys()):
            if geneName.startswith(toTest):
                 gene = geneName
 

--- a/conga/tcrdist/make_10x_clones_file.py
+++ b/conga/tcrdist/make_10x_clones_file.py
@@ -5,6 +5,7 @@ from .all_genes import all_genes
 #import parse_tsv
 from collections import Counter
 from itertools import chain
+from natsort import natsorted
 import sys
 import pandas as pd
 from ..util import organism2vdj_type, IG_VDJ_TYPE
@@ -23,8 +24,12 @@ def fixup_gene_name( gene, gene_suffix, expected_gene_names ):
     if gene in expected_gene_names:
         return gene # ALL DONE
 
+    # This should select the lowest allele
     if '*' not in gene:
-        gene += gene_suffix
+        toTest = gene + '*'
+        for geneName in natsorted(expected_gene_names.keys()):
+           if geneName.startswith(toTest):
+                gene = geneName
 
     if gene in expected_gene_names:
         return gene # ALL DONE

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Natural Language :: English',
     ],
 
-    install_requires=["scanpy", "leidenalg", "natsort"],
+    install_requires=["scanpy", "leidenalg"],
 
     packages=['conga','conga.tcrdist'],
     #packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Natural Language :: English',
     ],
 
-    install_requires=["scanpy", "leidenalg"],
+    install_requires=["scanpy", "leidenalg", "natsort"],
 
     packages=['conga','conga.tcrdist'],
     #packages=find_packages(),


### PR DESCRIPTION
@sschattgen: this is a suggestion related to our email in December. This probably would help the situation with Rhesus macaques, where some segments do not have an *01 allele, but they do have *02.